### PR TITLE
Upgrade to maven-checkstyle-plugin 2.14-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>2.12.1</version>
+                <version>2.14-SNAPSHOT</version>
                 <executions>
                     <execution>
                         <id>modernizer</id>
@@ -150,9 +150,19 @@
         </plugins>
     </build>
 
+    <pluginRepositories>
+        <pluginRepository>
+            <id>apache-plugin-snapshots</id>
+            <url>https://repository.apache.org/content/repositories/snapshots</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
+
     <repositories>
         <repository>
-            <id>jclouds-snapshots</id>
+            <id>apache-snapshots</id>
             <url>https://repository.apache.org/content/repositories/snapshots</url>
             <snapshots>
                 <enabled>true</enabled>


### PR DESCRIPTION
This release supports Java 8 syntax, notably lambda.  Changelog:

https://jira.codehaus.org/secure/ReleaseNote.jspa?projectId=11127&version=20631
