### PR TITLE
Specify Checkstyle version explicitly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,14 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>2.14-SNAPSHOT</version>
+                <version>2.13</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.puppycrawl.tools</groupId>
+                        <artifactId>checkstyle</artifactId>
+                        <version>5.9</version>
+                    </dependency>
+                </dependencies>
                 <executions>
                     <execution>
                         <id>checkstyle</id>


### PR DESCRIPTION
This allows maven-checkstyle-plugin to parse Java 8 lambdas.

References https://jira.codehaus.org/browse/MCHECKSTYLE-253 and
https://jira.codehaus.org/browse/MCHECKSTYLE-261.
