### PR TITLE
Upgrade to maven-checkstyle-plugin 2.14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,12 +25,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>2.13</version>
+                <version>2.14</version>
                 <dependencies>
                     <dependency>
                         <groupId>com.puppycrawl.tools</groupId>
                         <artifactId>checkstyle</artifactId>
-                        <version>5.9</version>
+                        <version>6.3</version>
                     </dependency>
                 </dependencies>
                 <executions>
@@ -165,16 +165,6 @@
             </plugin>
         </plugins>
     </build>
-
-    <pluginRepositories>
-        <pluginRepository>
-            <id>apache-plugin-snapshots</id>
-            <url>https://repository.apache.org/content/repositories/snapshots</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </pluginRepository>
-    </pluginRepositories>
 
     <repositories>
         <repository>

--- a/src/main/resources/checkstyle.xml
+++ b/src/main/resources/checkstyle.xml
@@ -105,9 +105,6 @@
     <module name="ParenPad"/>
     <module name="RedundantImport"/>
     <module name="RedundantModifier"/>
-    <module name="RedundantThrows">
-      <property name="suppressLoadErrors" value="true"/>
-    </module>
     <module name="RightCurly"/>
     <module name="SimplifyBooleanExpression"/>
     <module name="SimplifyBooleanReturn"/>


### PR DESCRIPTION
Also specify latest Checkstyle 6.3 for improved Java 8 support.
Disable now-removed RedundantThrows check.  Remove unused Apache
plugin snapshots repository.

Release notes:

http://mail-archives.apache.org/mod_mbox/maven-announce/201502.mbox/browser
http://checkstyle.sourceforge.net/releasenotes.html
