### PR TITLE
Use ephemeral ports in tests for S3 proxy.

### DIFF
--- a/src/test/resources/bounce.properties
+++ b/src/test/resources/bounce.properties
@@ -1,4 +1,4 @@
-s3proxy.endpoint=http://0.0.0.0:8080
+s3proxy.endpoint=http://0.0.0.0:0
 s3proxy.authorization=aws-v2
 s3proxy.identity=local-identity
 s3proxy.credential=local-credential


### PR DESCRIPTION
We should use ephemeral ports in tests when starting S3 proxy.
