### PR TITLE
Avoid duplication in {get|put}Blob implementation.

### DIFF
--- a/src/main/java/com/bouncestorage/bounce/BounceBlobStore.java
+++ b/src/main/java/com/bouncestorage/bounce/BounceBlobStore.java
@@ -169,9 +169,7 @@ public final class BounceBlobStore implements BlobStore {
 
     @Override
     public String putBlob(String containerName, Blob blob) {
-        String etag = nearStore.putBlob(containerName, blob);
-        farStore.removeBlob(containerName, blob.getMetadata().getName());
-        return etag;
+        return putBlob(containerName, blob, PutOptions.NONE);
     }
 
     @Override
@@ -199,12 +197,7 @@ public final class BounceBlobStore implements BlobStore {
 
     @Override
     public Blob getBlob(String containerName, String blobName) {
-        Blob b = nearStore.getBlob(containerName, blobName);
-        if (BounceLink.isLink(b.getMetadata())) {
-            return farStore.getBlob(containerName, blobName);
-        } else {
-            return b;
-        }
+        return getBlob(containerName, blobName, GetOptions.NONE);
     }
 
     @Override


### PR DESCRIPTION
There are two methods for getBlob and putBlob:
{get|put}Blob(container, blob) and
{get|put}Blob(container, blob, options)

We can implement the first method by calling the second one with the
{Get|Put}Options.NONE argument, as otherwise we duplicate the
implementation details.
