### PR TITLE
Fix a unit test failure.

### DIFF
--- a/src/test/java/com/bouncestorage/bounce/BounceApplicationTest.java
+++ b/src/test/java/com/bouncestorage/bounce/BounceApplicationTest.java
@@ -41,7 +41,9 @@ public final class BounceApplicationTest {
                 Constants.PROPERTY_PROVIDER, "transient");
         AbstractConfiguration config = new MapConfiguration((Map) properties);
         BounceApplication app = new BounceApplication(config);
-        app.run(new String[] {"server", webConfig});
+        synchronized (BounceApplication.class) {
+            app.run(new String[]{"server", webConfig});
+        }
 
         while (!app.getS3ProxyState().equals(AbstractLifeCycle.STARTED)) {
             Thread.sleep(10);


### PR DESCRIPTION
Synchronize the invocations of the BounceApplication.run() method.
The test case appears to no longer fail, but I don't understand why
this is necessary :)

Fixes: #70
