### PR TITLE
Do not remove an object from the farStore on PUT.

### DIFF
--- a/src/main/java/com/bouncestorage/bounce/BounceBlobStore.java
+++ b/src/main/java/com/bouncestorage/bounce/BounceBlobStore.java
@@ -175,7 +175,6 @@ public final class BounceBlobStore implements BlobStore {
     @Override
     public String putBlob(String containerName, Blob blob, PutOptions putOptions) {
         String etag = nearStore.putBlob(containerName, blob, putOptions);
-        farStore.removeBlob(containerName, blob.getMetadata().getName());
         return etag;
     }
 


### PR DESCRIPTION
We do not need to remove the object from the farStore on PUT, as we
always go to the nearStore first.
