### PR TITLE
Add copyBlob() method to BounceBlobstore.

### DIFF
--- a/src/main/java/com/bouncestorage/bounce/BounceBlobStore.java
+++ b/src/main/java/com/bouncestorage/bounce/BounceBlobStore.java
@@ -253,13 +253,16 @@ public final class BounceBlobStore implements BlobStore {
 
     public void copyBlobAndCreateBounceLink(String containerName, String blobName)
             throws IOException {
-        Blob blobFrom = Utils.copyBlob(nearStore, farStore, containerName,
-                containerName, blobName);
+        Blob blobFrom = copyBlob(containerName, blobName);
         if (blobFrom == null) {
             return;
         }
         BounceLink link = new BounceLink(Optional.of(blobFrom.getMetadata()));
         nearStore.putBlob(containerName, link.toBlob(nearStore));
+    }
+
+    public Blob copyBlob(String containerName, String blobName) throws IOException {
+        return Utils.copyBlob(nearStore, farStore, containerName, containerName, blobName);
     }
 
     public void takeOver(String containerName) throws IOException {

--- a/src/test/java/com/bouncestorage/bounce/BounceTest.java
+++ b/src/test/java/com/bouncestorage/bounce/BounceTest.java
@@ -140,6 +140,17 @@ public final class BounceTest {
         assertEqualBlobs(farBlob, blob);
     }
 
+    @Test
+    public void testCopyBlob() throws Exception {
+        String blobName = "blob";
+        Blob blob = UtilsTest.makeBlob(nearBlobStore, blobName);
+        nearBlobStore.putBlob(containerName, blob);
+        assertThat(nearBlobStore.blobExists(containerName, blobName));
+        bounceBlobStore.copyBlob(containerName, blobName);
+        Blob farBlob = farBlobStore.getBlob(containerName, blobName);
+        assertEqualBlobs(farBlob, blob);
+    }
+
     private void assertEqualBlobs(Blob one, Blob two) throws Exception {
         try (InputStream is = one.getPayload().openStream();
              InputStream is2 = two.getPayload().openStream()) {


### PR DESCRIPTION
Adds the copyBlob() method to the public API exposed by the
BounceBlobstore. The method copies a blob into the "far" store from
the "near" store. This is necessary for the copyBounce policy.

Refs: #29
