### PR TITLE
Pass BlobStore and container with StorageMetadata.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -273,6 +273,12 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>com.google.auto.value</groupId>
+            <artifactId>auto-value</artifactId>
+            <version>1.0-rc1</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>commons-configuration</groupId>
             <artifactId>commons-configuration</artifactId>
             <version>1.10</version>

--- a/src/main/java/com/bouncestorage/bounce/BounceBlobStore.java
+++ b/src/main/java/com/bouncestorage/bounce/BounceBlobStore.java
@@ -267,10 +267,10 @@ public final class BounceBlobStore implements BlobStore {
 
     public void takeOver(String containerName) throws IOException {
         // TODO: hook into move service to enable parallelism and cancellation
-        for (StorageMetadata sm : Utils.crawlBlobStore(farStore,
+        for (Utils.ListBlobMetadata sm : Utils.crawlBlobStore(farStore,
                 containerName)) {
             BlobMetadata metadata = farStore.blobMetadata(containerName,
-                    sm.getName());
+                    sm.metadata().getName());
             BounceLink link = new BounceLink(Optional.of(metadata));
             nearStore.putBlob(containerName, link.toBlob(nearStore));
         }

--- a/src/main/java/com/bouncestorage/bounce/admin/BouncePolicy.java
+++ b/src/main/java/com/bouncestorage/bounce/admin/BouncePolicy.java
@@ -9,11 +9,11 @@ import java.io.IOException;
 import java.util.function.Predicate;
 
 import com.bouncestorage.bounce.BounceBlobStore;
+import com.bouncestorage.bounce.Utils;
 
 import org.apache.commons.configuration.Configuration;
-import org.jclouds.blobstore.domain.StorageMetadata;
 
-public interface BouncePolicy extends Predicate<StorageMetadata> {
+public interface BouncePolicy extends Predicate<Utils.ListBlobMetadata> {
     default void init(BounceService service, Configuration config) {
     }
 

--- a/src/main/java/com/bouncestorage/bounce/admin/BounceService.java
+++ b/src/main/java/com/bouncestorage/bounce/admin/BounceService.java
@@ -20,7 +20,6 @@ import com.bouncestorage.bounce.admin.policy.BounceNothingPolicy;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import org.apache.commons.configuration.event.ConfigurationListener;
-import org.jclouds.blobstore.domain.StorageMetadata;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -113,7 +112,7 @@ public final class BounceService {
             StreamSupport.stream(Utils.crawlBlobStore(bounceStore, container).spliterator(), /*parallel=*/ false)
                     .peek(x -> status.totalObjectCount.getAndIncrement())
                     .filter(bouncePolicy)
-                    .map(StorageMetadata::getName)
+                    .map(blobMetadata -> blobMetadata.metadata().getName())
                     .filter(blobName -> !bounceStore.isLink(container, blobName))
                     .forEach(blobName -> {
                         try {

--- a/src/main/java/com/bouncestorage/bounce/admin/ContainerResource.java
+++ b/src/main/java/com/bouncestorage/bounce/admin/ContainerResource.java
@@ -21,8 +21,6 @@ import com.bouncestorage.bounce.BounceBlobStore;
 import com.bouncestorage.bounce.Utils;
 import com.codahale.metrics.annotation.Timed;
 
-import org.jclouds.blobstore.domain.StorageMetadata;
-
 @Path("/container")
 @Produces(MediaType.APPLICATION_JSON)
 public final class ContainerResource {
@@ -37,11 +35,11 @@ public final class ContainerResource {
     public ContainerStats getContainerStats(
             @QueryParam("name") String containerName) {
         BounceBlobStore blobStore = app.getBlobStore();
-        Iterable<StorageMetadata> metas = Utils.crawlBlobStore(blobStore,
+        Iterable<Utils.ListBlobMetadata> metas = Utils.crawlBlobStore(blobStore,
                 containerName);
         List<String> blobNames =
                 StreamSupport.stream(metas.spliterator(), /*parallel=*/ false)
-                .map(sm -> sm.getName())
+                .map(sm -> sm.metadata().getName())
                 .collect(Collectors.toList());
         long bounceLinkCount = blobNames.stream()
                 .filter(blobName -> blobStore.isLink(containerName, blobName))

--- a/src/main/java/com/bouncestorage/bounce/admin/policy/BounceNothingPolicy.java
+++ b/src/main/java/com/bouncestorage/bounce/admin/policy/BounceNothingPolicy.java
@@ -5,13 +5,12 @@
 
 package com.bouncestorage.bounce.admin.policy;
 
+import com.bouncestorage.bounce.Utils;
 import com.bouncestorage.bounce.admin.BouncePolicy;
-
-import org.jclouds.blobstore.domain.StorageMetadata;
 
 public final class BounceNothingPolicy implements BouncePolicy {
     @Override
-    public boolean test(StorageMetadata metadata) {
+    public boolean test(Utils.ListBlobMetadata blobMetadata) {
         return false;
     }
 }

--- a/src/main/java/com/bouncestorage/bounce/admin/policy/LastModifiedTimePolicy.java
+++ b/src/main/java/com/bouncestorage/bounce/admin/policy/LastModifiedTimePolicy.java
@@ -10,12 +10,12 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.time.Duration;
 import java.time.Instant;
 
+import com.bouncestorage.bounce.Utils;
 import com.bouncestorage.bounce.admin.BouncePolicy;
 import com.bouncestorage.bounce.admin.BounceService;
 import com.google.auto.service.AutoService;
 
 import org.apache.commons.configuration.Configuration;
-import org.jclouds.blobstore.domain.StorageMetadata;
 
 @AutoService(BouncePolicy.class)
 public final class LastModifiedTimePolicy extends MovePolicy {
@@ -29,9 +29,9 @@ public final class LastModifiedTimePolicy extends MovePolicy {
     }
 
     @Override
-    public boolean test(StorageMetadata metadata) {
+    public boolean test(Utils.ListBlobMetadata blobMetadata) {
         Instant now = service.getClock().instant();
-        Instant then = metadata.getLastModified().toInstant();
+        Instant then = blobMetadata.metadata().getLastModified().toInstant();
         return now.minus(timeAgo).isAfter(then);
     }
 }

--- a/src/main/java/com/bouncestorage/bounce/admin/policy/MoveEverythingPolicy.java
+++ b/src/main/java/com/bouncestorage/bounce/admin/policy/MoveEverythingPolicy.java
@@ -5,10 +5,9 @@
 
 package com.bouncestorage.bounce.admin.policy;
 
+import com.bouncestorage.bounce.Utils;
 import com.bouncestorage.bounce.admin.BouncePolicy;
 import com.google.auto.service.AutoService;
-
-import org.jclouds.blobstore.domain.StorageMetadata;
 
 @AutoService(BouncePolicy.class)
 public final class MoveEverythingPolicy extends MovePolicy {
@@ -18,7 +17,7 @@ public final class MoveEverythingPolicy extends MovePolicy {
     }
 
     @Override
-    public boolean test(StorageMetadata metadata) {
+    public boolean test(Utils.ListBlobMetadata blobMetadata) {
         return true;
     }
 }

--- a/src/test/java/com/bouncestorage/bounce/UtilsTest.java
+++ b/src/test/java/com/bouncestorage/bounce/UtilsTest.java
@@ -24,7 +24,6 @@ import org.jclouds.ContextBuilder;
 import org.jclouds.blobstore.BlobStore;
 import org.jclouds.blobstore.BlobStoreContext;
 import org.jclouds.blobstore.domain.Blob;
-import org.jclouds.blobstore.domain.StorageMetadata;
 import org.jclouds.blobstore.options.ListContainerOptions;
 import org.jclouds.io.ContentMetadata;
 import org.jclouds.logging.slf4j.config.SLF4JLoggingModule;
@@ -104,10 +103,10 @@ public final class UtilsTest {
         ContentMetadata metadata = blob.getMetadata().getContentMetadata();
         nearBlobStore.putBlob(containerName, blob);
 
-        for (StorageMetadata sm : Utils.crawlBlobStore(nearBlobStore,
+        for (Utils.ListBlobMetadata blobMetadata : Utils.crawlBlobStore(nearBlobStore,
                 containerName)) {
             Utils.moveBlob(nearBlobStore, farBlobStore, containerName,
-                    containerName, sm.getName());
+                    containerName, blobMetadata.metadata().getName());
         }
 
         Blob blob2 = farBlobStore.getBlob(containerName, blobName);
@@ -169,10 +168,10 @@ public final class UtilsTest {
         assertThat(Utils.crawlBlobStore(nearBlobStore, containerName))
                 .hasSize(1);
 
-        for (StorageMetadata sm : Utils.crawlBlobStore(nearBlobStore,
+        for (Utils.ListBlobMetadata blobMetadata : Utils.crawlBlobStore(nearBlobStore,
                 containerName)) {
             Utils.moveBlob(nearBlobStore, farBlobStore, containerName,
-                    containerName, sm.getName());
+                    containerName, blobMetadata.metadata().getName());
         }
     }
 

--- a/src/test/java/com/bouncestorage/bounce/admin/BounceServiceTest.java
+++ b/src/test/java/com/bouncestorage/bounce/admin/BounceServiceTest.java
@@ -15,6 +15,7 @@ import java.util.Optional;
 import java.util.Properties;
 
 import com.bouncestorage.bounce.BounceBlobStore;
+import com.bouncestorage.bounce.Utils;
 import com.bouncestorage.bounce.UtilsTest;
 import com.bouncestorage.bounce.admin.BounceService.BounceTaskStatus;
 import com.bouncestorage.bounce.admin.policy.LastModifiedTimePolicy;
@@ -90,11 +91,11 @@ public final class BounceServiceTest {
         BouncePolicy p = lastModifiedTimePolicy(Duration.ofHours(1));
         Blob blob = UtilsTest.makeBlob(blobStore, UtilsTest.createRandomBlobName());
         blob.getMetadata().setLastModified(Date.from(bounceService.getClock().instant()));
-        assertThat(p.test(blob.getMetadata())).isFalse();
+        assertThat(p.test(Utils.ListBlobMetadata.create(blobStore, containerName, blob.getMetadata()))).isFalse();
 
         advanceServiceClock(Duration.ofHours(2));
 
-        assertThat(p.test(blob.getMetadata())).isTrue();
+        assertThat(p.test(Utils.ListBlobMetadata.create(blobStore, containerName, blob.getMetadata()))).isTrue();
     }
 
     @Test


### PR DESCRIPTION
StorageMetadata on its own is not always sufficient (at least today)
to decide whether an object should be bounced or not. We may need to
interrogate the object store to make a decision. To resolve this, the
patch adds a ListBlobMetadata wrapper class that includes the
container name and the BlobStore instance. Both are required to look
up any additional metadata.

Refs: #29
