### PR TITLE
Add the CopyBounce policy.

### DIFF
--- a/src/main/java/com/bouncestorage/bounce/admin/policy/CopyPolicy.java
+++ b/src/main/java/com/bouncestorage/bounce/admin/policy/CopyPolicy.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Bounce Storage, Inc. All rights reserved.
+ * For more information, please see COPYRIGHT in the top-level directory.
+ */
+
+package com.bouncestorage.bounce.admin.policy;
+
+import java.io.IOException;
+import java.util.Map;
+
+import com.bouncestorage.bounce.BounceBlobStore;
+import com.bouncestorage.bounce.BounceLink;
+import com.bouncestorage.bounce.admin.BouncePolicy;
+import com.bouncestorage.bounce.admin.BounceService;
+
+import org.apache.commons.configuration.Configuration;
+import org.jclouds.blobstore.domain.Blob;
+import org.jclouds.blobstore.domain.BlobMetadata;
+import org.jclouds.blobstore.domain.StorageMetadata;
+
+public final class CopyPolicy implements BouncePolicy {
+    public static final String COPIED_METADATA_KEY = "bounce-copied";
+
+    private BounceService service;
+
+    @Override
+    public void init(BounceService bounceService, Configuration settings) {
+        service = bounceService;
+    }
+
+    @Override
+    public boolean test(StorageMetadata metadata) {
+        return true;
+    }
+
+    @Override
+    public BounceResult bounce(BlobMetadata blobMetadata, BounceBlobStore blobStore) throws IOException {
+        if (BounceLink.isLink(blobMetadata)) {
+            return BounceResult.NO_OP;
+        }
+
+        if (blobMetadata.getUserMetadata().containsKey(COPIED_METADATA_KEY)) {
+            return BounceResult.NO_OP;
+        }
+        blobStore.copyBlob(blobMetadata.getContainer(), blobMetadata.getName());
+        Blob blob = blobStore.getBlob(blobMetadata.getContainer(), blobMetadata.getName());
+        Map<String, String> userMetadata = blobMetadata.getUserMetadata();
+        userMetadata.put(COPIED_METADATA_KEY, "true");
+        blob.getMetadata().setUserMetadata(userMetadata);
+        blobStore.putBlob(blobMetadata.getContainer(), blob);
+        return BounceResult.COPY;
+    }
+}

--- a/src/main/java/com/bouncestorage/bounce/admin/policy/MovePolicy.java
+++ b/src/main/java/com/bouncestorage/bounce/admin/policy/MovePolicy.java
@@ -15,6 +15,9 @@ import org.jclouds.blobstore.domain.BlobMetadata;
 public abstract class MovePolicy implements BouncePolicy {
     @Override
     public final BounceResult bounce(BlobMetadata meta, BounceBlobStore bounceBlobStore) throws IOException {
+        if (meta.getUserMetadata().containsKey(CopyPolicy.COPIED_METADATA_KEY)) {
+            return BounceResult.NO_OP;
+        }
         bounceBlobStore.copyBlobAndCreateBounceLink(meta.getContainer(), meta.getName());
         return BounceResult.MOVE;
     }


### PR DESCRIPTION
Implements the naive implementation of CopyBounce. The implementation
is as follows:
1. Lookup the blob metadata to check whether the "bounce-copied" tag
   is set
2. Copy the blob to the other store
3. Set the metatag that the blob has been copied

This is not great, because to set the tag, we have to re-upload the
blob.
