### PR TITLE
Fixes for the copy policy.

### DIFF
--- a/src/main/java/com/bouncestorage/bounce/admin/policy/CopyPolicy.java
+++ b/src/main/java/com/bouncestorage/bounce/admin/policy/CopyPolicy.java
@@ -6,27 +6,17 @@
 package com.bouncestorage.bounce.admin.policy;
 
 import java.io.IOException;
-import java.util.Map;
 
 import com.bouncestorage.bounce.BounceBlobStore;
 import com.bouncestorage.bounce.BounceLink;
 import com.bouncestorage.bounce.admin.BouncePolicy;
-import com.bouncestorage.bounce.admin.BounceService;
+import com.google.common.collect.ImmutableMap;
 
-import org.apache.commons.configuration.Configuration;
-import org.jclouds.blobstore.domain.Blob;
 import org.jclouds.blobstore.domain.BlobMetadata;
 import org.jclouds.blobstore.domain.StorageMetadata;
 
 public final class CopyPolicy implements BouncePolicy {
     public static final String COPIED_METADATA_KEY = "bounce-copied";
-
-    private BounceService service;
-
-    @Override
-    public void init(BounceService bounceService, Configuration settings) {
-        service = bounceService;
-    }
 
     @Override
     public boolean test(StorageMetadata metadata) {
@@ -43,11 +33,8 @@ public final class CopyPolicy implements BouncePolicy {
             return BounceResult.NO_OP;
         }
         blobStore.copyBlob(blobMetadata.getContainer(), blobMetadata.getName());
-        Blob blob = blobStore.getBlob(blobMetadata.getContainer(), blobMetadata.getName());
-        Map<String, String> userMetadata = blobMetadata.getUserMetadata();
-        userMetadata.put(COPIED_METADATA_KEY, "true");
-        blob.getMetadata().setUserMetadata(userMetadata);
-        blobStore.putBlob(blobMetadata.getContainer(), blob);
+        blobStore.updateBlobMetadata(blobMetadata.getContainer(), blobMetadata.getName(), ImmutableMap.of(
+                COPIED_METADATA_KEY, "true"));
         return BounceResult.COPY;
     }
 }

--- a/src/main/java/com/bouncestorage/bounce/admin/policy/MovePolicy.java
+++ b/src/main/java/com/bouncestorage/bounce/admin/policy/MovePolicy.java
@@ -16,6 +16,7 @@ public abstract class MovePolicy implements BouncePolicy {
     @Override
     public final BounceResult bounce(BlobMetadata meta, BounceBlobStore bounceBlobStore) throws IOException {
         if (meta.getUserMetadata().containsKey(CopyPolicy.COPIED_METADATA_KEY)) {
+            bounceBlobStore.createBounceLink(meta);
             return BounceResult.NO_OP;
         }
         bounceBlobStore.copyBlobAndCreateBounceLink(meta.getContainer(), meta.getName());

--- a/src/test/java/com/bouncestorage/bounce/BounceTest.java
+++ b/src/test/java/com/bouncestorage/bounce/BounceTest.java
@@ -7,6 +7,7 @@ package com.bouncestorage.bounce;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.io.ByteSource;
 
 import org.jclouds.blobstore.BlobStore;
@@ -149,4 +150,16 @@ public final class BounceTest {
         UtilsTest.assertEqualBlobs(farBlob, blob);
     }
 
+    @Test
+    public void testUpdateMetadataTest() throws Exception {
+        String blobName = UtilsTest.createRandomBlobName();
+        Blob blob = UtilsTest.makeBlob(bounceBlobStore, blobName);
+        blob.getMetadata().setUserMetadata(ImmutableMap.of("foo", "1"));
+        bounceBlobStore.putBlob(containerName, blob);
+        assertThat(bounceBlobStore.blobMetadata(containerName, blobName).getUserMetadata()).containsKey("foo");
+        assertThat(bounceBlobStore.blobMetadata(containerName, blobName).getUserMetadata()).doesNotContainKey("bar");
+        bounceBlobStore.updateBlobMetadata(containerName, blobName, ImmutableMap.of("bar", "2"));
+        assertThat(bounceBlobStore.blobMetadata(containerName, blobName).getUserMetadata()).containsKey("foo");
+        assertThat(bounceBlobStore.blobMetadata(containerName, blobName).getUserMetadata()).containsKey("bar");
+    }
 }


### PR DESCRIPTION
Add an updateMetadata method in BounceBlobstore, as putBlob removes
the file from the farStore.

If MovePolicy bounce executes after CopyPolicy bounce, create a
symlink out of the file in the near store. createBounceLink() method
was added for this purpose.
