### PR TITLE
Do not call ContextBuilder.overrides() twice.

### DIFF
--- a/src/main/java/com/bouncestorage/bounce/admin/BounceApplication.java
+++ b/src/main/java/com/bouncestorage/bounce/admin/BounceApplication.java
@@ -128,10 +128,12 @@ public final class BounceApplication extends Application<BounceConfiguration> {
             return;
         }
         try {
+            Properties contextProperties = new Properties();
+            contextProperties.putAll(System.getProperties());
+            contextProperties.putAll(configView);
             BlobStoreContext context = ContextBuilder
                     .newBuilder("bounce")
-                    .overrides(System.getProperties())
-                    .overrides(configView)
+                    .overrides(contextProperties)
                     .build(BlobStoreContext.class);
             useBlobStore((BounceBlobStore) context.getBlobStore());
             blobStoreListeners.forEach(cb -> cb.accept(context));


### PR DESCRIPTION
ContextBuilder.overrides() does not merge existing overrides with the
new set, but rather sets them to the argument value. We should merge
all overrides ourselves first and then call .overrides() one time.
