### PR TITLE
Allow specifying the blob stores for tests.

### DIFF
--- a/src/test/java/com/bouncestorage/bounce/BounceTest.java
+++ b/src/test/java/com/bouncestorage/bounce/BounceTest.java
@@ -31,7 +31,7 @@ public final class BounceTest {
     public void setUp() throws Exception {
         containerName = UtilsTest.createRandomContainerName();
 
-        bounceContext = UtilsTest.createTransientBounceBlobStore();
+        bounceContext = UtilsTest.createTestBounceBlobStore();
         bounceBlobStore = (BounceBlobStore) bounceContext.getBlobStore();
         nearBlobStore = bounceBlobStore.getNearStore();
         farBlobStore = bounceBlobStore.getFarStore();

--- a/src/test/java/com/bouncestorage/bounce/admin/BounceServiceTest.java
+++ b/src/test/java/com/bouncestorage/bounce/admin/BounceServiceTest.java
@@ -40,7 +40,7 @@ public final class BounceServiceTest {
     public void setUp() throws Exception {
         containerName = UtilsTest.createRandomContainerName();
 
-        bounceContext = UtilsTest.createTransientBounceBlobStore();
+        bounceContext = UtilsTest.createTestBounceBlobStore();
         blobStore = (BounceBlobStore) bounceContext.getBlobStore();
         blobStore.createContainerInLocation(null, containerName);
 


### PR DESCRIPTION
Adds the ability to specify the blobstore to use for tests.
The patch builds the blobstore context incorporating the Java
properties. If either blobstore is not configured through the Java
properties, the method defaults to using the transient blobstore.
