### PR TITLE
Fix deleteContainer.

### DIFF
--- a/bounce/src/main/java/com/bouncestorage/bounce/admin/BouncePolicy.java
+++ b/bounce/src/main/java/com/bouncestorage/bounce/admin/BouncePolicy.java
@@ -78,6 +78,12 @@ public abstract class BouncePolicy implements IForwardingBlobStore {
         }
     }
 
+    @Override
+    public void deleteContainer(String containerName) {
+        getSource().deleteContainer(containerName);
+        getDestination().deleteContainer(containerName);
+    }
+
     /**
      * Sanity check that near store and far store are in sync, if they aren't,
      * we need to perform takeover.

--- a/bounce/src/test/java/com/bouncestorage/bounce/admin/policy/MigrationPolicyTest.java
+++ b/bounce/src/test/java/com/bouncestorage/bounce/admin/policy/MigrationPolicyTest.java
@@ -58,6 +58,14 @@ public final class MigrationPolicyTest {
             policy.deleteContainer(containerName);
         }
     }
+
+    @Test
+    public void testDeleteContainer() {
+        policy.deleteContainer(containerName);
+        assertThat(policy.getSource().containerExists(containerName)).isFalse();
+        assertThat(policy.getDestination().containerExists(containerName)).isFalse();
+    }
+
     @Test
     public void testListDestinationOnly() throws Exception {
         String[] blobNames = {"abc", "def", "ghi"};

--- a/bounce/src/test/java/com/bouncestorage/bounce/admin/policy/WriteBackPolicyTest.java
+++ b/bounce/src/test/java/com/bouncestorage/bounce/admin/policy/WriteBackPolicyTest.java
@@ -57,6 +57,13 @@ public final class WriteBackPolicyTest {
     }
 
     @Test
+    public void testDeleteContainer() {
+        policy.deleteContainer(containerName);
+        assertThat(policy.getSource().containerExists(containerName)).isFalse();
+        assertThat(policy.getDestination().containerExists(containerName)).isFalse();
+    }
+
+    @Test
     public void testMoveObject() throws Exception {
         String blobName = UtilsTest.createRandomBlobName();
         Blob blob = UtilsTest.makeBlob(policy, blobName);


### PR DESCRIPTION
Delete container in the current implementation only removes the
containers from the policy.getSource() location, but not from
policy.getDestination(). This results in littering many containers in
S3 when running tests.
