### PR TITLE
Strip beginning and ending quotes on ETags.

### DIFF
--- a/bounce/src/main/java/com/bouncestorage/bounce/admin/policy/MigrationPolicy.java
+++ b/bounce/src/main/java/com/bouncestorage/bounce/admin/policy/MigrationPolicy.java
@@ -76,7 +76,7 @@ public final class MigrationPolicy extends BouncePolicy {
             return moveObject(container, sourceMeta);
         }
 
-        if (sourceMeta.getETag().equalsIgnoreCase(destinationMeta.getETag())) {
+        if (Utils.eTagsEqual(sourceMeta.getETag(), destinationMeta.getETag())) {
             getSource().removeBlob(container, sourceMeta.getName());
             return BounceResult.REMOVE;
         } else {

--- a/bounce/src/main/java/com/bouncestorage/bounce/admin/policy/MovePolicy.java
+++ b/bounce/src/main/java/com/bouncestorage/bounce/admin/policy/MovePolicy.java
@@ -65,7 +65,7 @@ public abstract class MovePolicy extends MarkerPolicy {
         if (sourceObject.getRegions().equals(BounceBlobStore.EVERYWHERE)) {
             BlobMetadata sourceMetadata = getSource().blobMetadata(container, sourceObject.getName());
             BlobMetadata destinationMetadata = getDestination().blobMetadata(container, destinationObject.getName());
-            if (destinationMetadata.getETag().equalsIgnoreCase(sourceMetadata.getETag())) {
+            if (Utils.eTagsEqual(destinationMetadata.getETag(), sourceMetadata.getETag())) {
                 Utils.createBounceLink(this, sourceMetadata);
                 return BounceResult.LINK;
             }


### PR DESCRIPTION
S3 returns the ETag header with leading and trailing quotes ("). We
should strip these off before making a comparison against ETags
obtained from other providers (e.g. Swift, file system, or transient).
