### PR TITLE
Adapt the interface changes for multi-part upload.

### DIFF
--- a/bounce/src/main/java/com/bouncestorage/bounce/BounceBlobStore.java
+++ b/bounce/src/main/java/com/bouncestorage/bounce/BounceBlobStore.java
@@ -7,6 +7,7 @@ package com.bouncestorage.bounce;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -25,6 +26,8 @@ import org.jclouds.blobstore.domain.BlobAccess;
 import org.jclouds.blobstore.domain.BlobBuilder;
 import org.jclouds.blobstore.domain.BlobMetadata;
 import org.jclouds.blobstore.domain.ContainerAccess;
+import org.jclouds.blobstore.domain.MultipartPart;
+import org.jclouds.blobstore.domain.MultipartUpload;
 import org.jclouds.blobstore.domain.PageSet;
 import org.jclouds.blobstore.domain.StorageMetadata;
 import org.jclouds.blobstore.options.CopyOptions;
@@ -33,6 +36,7 @@ import org.jclouds.blobstore.options.GetOptions;
 import org.jclouds.blobstore.options.ListContainerOptions;
 import org.jclouds.blobstore.options.PutOptions;
 import org.jclouds.domain.Location;
+import org.jclouds.io.Payload;
 import org.jclouds.logging.Logger;
 import org.jclouds.providers.ProviderMetadata;
 
@@ -243,6 +247,46 @@ public final class BounceBlobStore implements BlobStore {
     @Override
     public long countBlobs(String container, ListContainerOptions listContainerOptions) {
         return policy.countBlobs(container, listContainerOptions);
+    }
+
+    @Override
+    public MultipartUpload initiateMultipartUpload(String s, BlobMetadata blobMetadata) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void abortMultipartUpload(MultipartUpload multipartUpload) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String completeMultipartUpload(MultipartUpload multipartUpload, List<MultipartPart> list) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public MultipartPart uploadMultipartPart(MultipartUpload multipartUpload, int i, Payload payload) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<MultipartPart> listMultipartUpload(MultipartUpload multipartUpload) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long getMinimumMultipartPartSize() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getMaximumNumberOfParts() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long getMaximumMultipartPartSize() {
+        throw new UnsupportedOperationException();
     }
 
     public void updateBlobMetadata(String containerName, String blobName, Map<String, String> userMetadata) {

--- a/bounce/src/main/java/com/bouncestorage/bounce/EncryptedBlobStore.java
+++ b/bounce/src/main/java/com/bouncestorage/bounce/EncryptedBlobStore.java
@@ -18,6 +18,7 @@ import java.io.SequenceInputStream;
 import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.security.spec.KeySpec;
+import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 
@@ -38,6 +39,8 @@ import org.jclouds.blobstore.domain.BlobAccess;
 import org.jclouds.blobstore.domain.BlobBuilder;
 import org.jclouds.blobstore.domain.BlobMetadata;
 import org.jclouds.blobstore.domain.ContainerAccess;
+import org.jclouds.blobstore.domain.MultipartPart;
+import org.jclouds.blobstore.domain.MultipartUpload;
 import org.jclouds.blobstore.domain.PageSet;
 import org.jclouds.blobstore.domain.StorageMetadata;
 import org.jclouds.blobstore.options.CopyOptions;
@@ -47,6 +50,7 @@ import org.jclouds.blobstore.options.ListContainerOptions;
 import org.jclouds.blobstore.options.PutOptions;
 import org.jclouds.domain.Location;
 import org.jclouds.io.ContentMetadata;
+import org.jclouds.io.Payload;
 import org.jclouds.logging.Logger;
 import org.jclouds.providers.ProviderMetadata;
 
@@ -297,5 +301,45 @@ public final class EncryptedBlobStore implements BlobStore {
     public String copyBlob(String fromContainer, String fromName, String toContainer, String toName,
                            CopyOptions options) {
         return delegate().copyBlob(fromContainer, fromName, toContainer, toName, options);
+    }
+
+    @Override
+    public MultipartUpload initiateMultipartUpload(String s, BlobMetadata blobMetadata) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void abortMultipartUpload(MultipartUpload multipartUpload) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String completeMultipartUpload(MultipartUpload multipartUpload, List<MultipartPart> list) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public MultipartPart uploadMultipartPart(MultipartUpload multipartUpload, int i, Payload payload) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<MultipartPart> listMultipartUpload(MultipartUpload multipartUpload) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long getMinimumMultipartPartSize() {
+        return delegate().getMinimumMultipartPartSize();
+    }
+
+    @Override
+    public int getMaximumNumberOfParts() {
+        return delegate().getMaximumNumberOfParts();
+    }
+
+    @Override
+    public long getMaximumMultipartPartSize() {
+        return delegate().getMaximumMultipartPartSize();
     }
 }

--- a/bounce/src/main/java/com/bouncestorage/bounce/IForwardingBlobStore.java
+++ b/bounce/src/main/java/com/bouncestorage/bounce/IForwardingBlobStore.java
@@ -6,6 +6,7 @@
 package com.bouncestorage.bounce;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -16,6 +17,8 @@ import org.jclouds.blobstore.domain.BlobAccess;
 import org.jclouds.blobstore.domain.BlobBuilder;
 import org.jclouds.blobstore.domain.BlobMetadata;
 import org.jclouds.blobstore.domain.ContainerAccess;
+import org.jclouds.blobstore.domain.MultipartPart;
+import org.jclouds.blobstore.domain.MultipartUpload;
 import org.jclouds.blobstore.domain.PageSet;
 import org.jclouds.blobstore.domain.StorageMetadata;
 import org.jclouds.blobstore.options.CopyOptions;
@@ -24,6 +27,7 @@ import org.jclouds.blobstore.options.GetOptions;
 import org.jclouds.blobstore.options.ListContainerOptions;
 import org.jclouds.blobstore.options.PutOptions;
 import org.jclouds.domain.Location;
+import org.jclouds.io.Payload;
 
 public interface IForwardingBlobStore extends BlobStore {
     BlobStore delegate();
@@ -208,5 +212,45 @@ public interface IForwardingBlobStore extends BlobStore {
     default String copyBlob(String fromContainer, String fromName, String toContainer, String toName,
                     CopyOptions options) {
         return delegate().copyBlob(mapContainer(fromContainer), fromName, mapContainer(toContainer), toName, options);
+    }
+
+    @Override
+    default MultipartUpload initiateMultipartUpload(String s, BlobMetadata blobMetadata) {
+        return delegate().initiateMultipartUpload(s, blobMetadata);
+    }
+
+    @Override
+    default void abortMultipartUpload(MultipartUpload multipartUpload) {
+        delegate().abortMultipartUpload(multipartUpload);
+    }
+
+    @Override
+    default String completeMultipartUpload(MultipartUpload multipartUpload, List<MultipartPart> list) {
+        return delegate().completeMultipartUpload(multipartUpload, list);
+    }
+
+    @Override
+    default MultipartPart uploadMultipartPart(MultipartUpload multipartUpload, int i, Payload payload) {
+        return delegate().uploadMultipartPart(multipartUpload, i, payload);
+    }
+
+    @Override
+    default List<MultipartPart> listMultipartUpload(MultipartUpload multipartUpload) {
+        return delegate().listMultipartUpload(multipartUpload);
+    }
+
+    @Override
+    default long getMinimumMultipartPartSize() {
+        return delegate().getMinimumMultipartPartSize();
+    }
+
+    @Override
+    default int getMaximumNumberOfParts() {
+        return delegate().getMaximumNumberOfParts();
+    }
+
+    @Override
+    default long getMaximumMultipartPartSize() {
+        return delegate().getMaximumMultipartPartSize();
     }
 }

--- a/bounce/src/main/java/com/bouncestorage/bounce/utils/nil/NullBlobStore.java
+++ b/bounce/src/main/java/com/bouncestorage/bounce/utils/nil/NullBlobStore.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.time.Instant;
 import java.util.Date;
+import java.util.List;
 import java.util.Set;
 
 import javax.inject.Inject;
@@ -28,6 +29,8 @@ import org.jclouds.blobstore.domain.BlobAccess;
 import org.jclouds.blobstore.domain.BlobBuilder;
 import org.jclouds.blobstore.domain.BlobMetadata;
 import org.jclouds.blobstore.domain.ContainerAccess;
+import org.jclouds.blobstore.domain.MultipartPart;
+import org.jclouds.blobstore.domain.MultipartUpload;
 import org.jclouds.blobstore.domain.PageSet;
 import org.jclouds.blobstore.domain.StorageMetadata;
 import org.jclouds.blobstore.domain.internal.BlobMetadataImpl;
@@ -40,6 +43,7 @@ import org.jclouds.blobstore.options.PutOptions;
 import org.jclouds.blobstore.util.BlobUtils;
 import org.jclouds.domain.Location;
 import org.jclouds.io.MutableContentMetadata;
+import org.jclouds.io.Payload;
 import org.jclouds.io.payloads.BaseMutableContentMetadata;
 
 public final class NullBlobStore implements BlobStore {
@@ -207,5 +211,65 @@ public final class NullBlobStore implements BlobStore {
     @Override
     public long countBlobs(String container, ListContainerOptions options) {
         return 0;
+    }
+
+    @Override
+    public MultipartUpload initiateMultipartUpload(String s, BlobMetadata blobMetadata) {
+        return new MultipartUpload() {
+            @Override
+            public String containerName() {
+                return null;
+            }
+
+            @Override
+            public String blobName() {
+                return null;
+            }
+
+            @Override
+            public String id() {
+                return null;
+            }
+
+            @Override
+            public BlobMetadata blobMetadata() {
+                return null;
+            }
+        };
+    }
+
+    @Override
+    public void abortMultipartUpload(MultipartUpload multipartUpload) {
+
+    }
+
+    @Override
+    public String completeMultipartUpload(MultipartUpload multipartUpload, List<MultipartPart> list) {
+        return null;
+    }
+
+    @Override
+    public MultipartPart uploadMultipartPart(MultipartUpload multipartUpload, int i, Payload payload) {
+        return MultipartPart.create(i, -1, "");
+    }
+
+    @Override
+    public List<MultipartPart> listMultipartUpload(MultipartUpload multipartUpload) {
+        return ImmutableList.<MultipartPart>of();
+    }
+
+    @Override
+    public long getMinimumMultipartPartSize() {
+        return 1;
+    }
+
+    @Override
+    public int getMaximumNumberOfParts() {
+        return Integer.MAX_VALUE;
+    }
+
+    @Override
+    public long getMaximumMultipartPartSize() {
+        return Long.MAX_VALUE;
     }
 }


### PR DESCRIPTION
We need to adapt the changes for the multi-part upload interface that
was added to jclouds.

Note: encrypted blob store does not encrypt multi-part uploads.
