### PR TITLE
Guard against an NPE in the URL endpoint.

### DIFF
--- a/bounce/src/main/java/com/bouncestorage/bounce/admin/SettingsResource.java
+++ b/bounce/src/main/java/com/bouncestorage/bounce/admin/SettingsResource.java
@@ -37,14 +37,18 @@ public class SettingsResource {
     @Timed
     public Settings getSettings() throws URISyntaxException {
         Settings res = new Settings();
-        URI endpoint = new URI(app.getConfiguration().getString(
-                S3ProxyConstants.PROPERTY_ENDPOINT));
-        res.s3Address = endpoint.getHost();
-        res.s3Port = endpoint.getPort();
-        URI swiftEndpoint = new URI(app.getConfiguration().getString(
-                SwiftProxy.PROPERTY_ENDPOINT));
-        res.swiftAddress = swiftEndpoint.getHost();
-        res.swiftPort = swiftEndpoint.getPort();
+        String s3URL = app.getConfiguration().getString(S3ProxyConstants.PROPERTY_ENDPOINT);
+        if (s3URL != null) {
+            URI endpoint = new URI(s3URL);
+            res.s3Address = endpoint.getHost();
+            res.s3Port = endpoint.getPort();
+        }
+        String swiftURL = app.getConfiguration().getString(SwiftProxy.PROPERTY_ENDPOINT);
+        if (swiftURL != null) {
+            URI swiftEndpoint = new URI(swiftURL);
+            res.swiftAddress = swiftEndpoint.getHost();
+            res.swiftPort = swiftEndpoint.getPort();
+        }
         return res;
     }
 

--- a/bounce/src/test/java/com/bouncestorage/bounce/UtilsTest.java
+++ b/bounce/src/test/java/com/bouncestorage/bounce/UtilsTest.java
@@ -324,15 +324,17 @@ public final class UtilsTest {
         app.setClock(Clock.offset(app.getClock(), duration));
     }
 
-    public static String submitRequest(String url, String method, String json) throws Exception {
+    public static HttpURLConnection submitRequest(String url, String method, String json) throws Exception {
         HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
         connection.setRequestMethod(method);
         connection.setRequestProperty(HttpHeaders.CONTENT_TYPE, javax.ws.rs.core.MediaType.APPLICATION_JSON);
         connection.setDoOutput(true);
-        try (OutputStream os = connection.getOutputStream()) {
-            os.write(json.getBytes(StandardCharsets.UTF_8));
+        if (json != null) {
+            try (OutputStream os = connection.getOutputStream()) {
+                os.write(json.getBytes(StandardCharsets.UTF_8));
+            }
         }
 
-        return connection.getResponseMessage();
+        return connection;
     }
 }

--- a/bounce/src/test/java/com/bouncestorage/bounce/admin/ObjectStoreResourceTest.java
+++ b/bounce/src/test/java/com/bouncestorage/bounce/admin/ObjectStoreResourceTest.java
@@ -10,8 +10,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.InputStream;
+import java.net.HttpURLConnection;
 
 import javax.ws.rs.HttpMethod;
+import javax.ws.rs.core.Response;
 
 import com.bouncestorage.bounce.BounceBlobStore;
 import com.bouncestorage.bounce.UtilsTest;
@@ -36,7 +38,7 @@ public class ObjectStoreResourceTest {
         }
         app = new BounceApplication(configFile.getPath());
         app.useRandomPorts();
-        String webConfig = VirtualContainerResourceTest.class.getResource("/bounce.yml").toExternalForm();
+        String webConfig = ObjectStoreResourceTest.class.getResource("/bounce.yml").toExternalForm();
         synchronized (app.getClass()) {
             app.run(new String[]{"server", webConfig});
         }
@@ -70,8 +72,8 @@ public class ObjectStoreResourceTest {
 
     private void validateStores(String[] nicknames) throws Exception {
         for (int i = 0; i < nicknames.length; i++) {
-            String response = createObjectStore(nicknames[i]);
-            assertThat(response).isEqualToIgnoringCase("OK");
+            HttpURLConnection response = createObjectStore(nicknames[i]);
+            assertThat(response.getResponseCode()).isEqualTo(Response.Status.OK.getStatusCode());
             Configuration config = app.getConfiguration();
             assertThat(config.getList(BounceBlobStore.STORES_LIST)).hasSize(i + 1);
             String id = Integer.toString(i + 1);
@@ -82,7 +84,7 @@ public class ObjectStoreResourceTest {
         }
     }
 
-    private String createObjectStore(String nickname) throws Exception {
+    private HttpURLConnection createObjectStore(String nickname) throws Exception {
         String jsonInput = "{ \"provider\" : \"transient\", \"identity\" : \"foo\", \"credential\" : \"foo\", " +
                 "\"nickname\" : \"" + nickname + "\" }";
 

--- a/bounce/src/test/java/com/bouncestorage/bounce/admin/SettingsResourceTest.java
+++ b/bounce/src/test/java/com/bouncestorage/bounce/admin/SettingsResourceTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) Bounce Storage, Inc. All rights reserved.
+ * For more information, please see COPYRIGHT in the top-level directory.
+ */
+
+package com.bouncestorage.bounce.admin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.HashMap;
+
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.core.Response;
+
+import com.bouncestorage.bounce.UtilsTest;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class SettingsResourceTest {
+    private static final String settingsEndpoint = "/api/settings";
+    private BounceApplication app;
+
+    @Before
+    public void setUp() throws Exception {
+        app = new BounceApplication();
+        app.useRandomPorts();
+        String webConfig = SettingsResourceTest.class.getResource("/bounce.yml").toExternalForm();
+        synchronized (app.getClass()) {
+            app.run(new String[]{"server", webConfig});
+        }
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        app.stop();
+    }
+
+    @Test
+    public void testEmptySettings() throws Exception {
+        HttpURLConnection response = UtilsTest.submitRequest(getURL(), HttpMethod.GET, null);
+        assertThat(response.getResponseCode()).isEqualTo(Response.Status.OK.getStatusCode());
+    }
+
+    @Test
+    public void testConfigureS3Endpoint() throws Exception {
+        String json = "{\"s3Address\":\"127.0.0.42\", \"s3Port\": 10042}";
+        HttpURLConnection response = UtilsTest.submitRequest(getURL(), HttpMethod.POST, json);
+        assertThat(response.getResponseCode()).isEqualTo(Response.Status.OK.getStatusCode());
+        HashMap<String, String> settings = getSettings();
+        assertThat(settings).containsKey("s3Address");
+        assertThat(settings).containsKey("s3Port");
+        assertThat(settings.get("s3Address")).isEqualTo("127.0.0.42");
+        assertThat(settings.get("s3Port")).isEqualTo("10042");
+    }
+
+    @Test
+    public void testConfigureSwiftEndpoint() throws Exception {
+        String json = "{\"swiftAddress\":\"127.0.0.24\", \"swiftPort\": 10024}";
+        HttpURLConnection response = UtilsTest.submitRequest(getURL(), HttpMethod.POST, json);
+        assertThat(response.getResponseCode()).isEqualTo(Response.Status.OK.getStatusCode());
+        HashMap<String, String> settings = getSettings();
+        assertThat(settings).containsKey("swiftAddress");
+        assertThat(settings).containsKey("swiftPort");
+        assertThat(settings.get("swiftAddress")).isEqualTo("127.0.0.24");
+        assertThat(settings.get("swiftPort")).isEqualTo("10024");
+    }
+
+    private HashMap<String, String> getSettings() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.readValue(new URL(getURL()), new TypeReference<HashMap<String, String>>() { });
+    }
+
+    private String getURL() {
+        return "http://localhost:" + app.getPort() + settingsEndpoint;
+    }
+}

--- a/bounce/src/test/java/com/bouncestorage/bounce/admin/VirtualContainerResourceTest.java
+++ b/bounce/src/test/java/com/bouncestorage/bounce/admin/VirtualContainerResourceTest.java
@@ -7,9 +7,11 @@ package com.bouncestorage.bounce.admin;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.net.HttpURLConnection;
 import java.util.Properties;
 
 import javax.ws.rs.HttpMethod;
+import javax.ws.rs.core.Response;
 
 import com.bouncestorage.bounce.BounceBlobStore;
 import com.bouncestorage.bounce.UtilsTest;
@@ -51,8 +53,8 @@ public class VirtualContainerResourceTest {
 
         String url = String.format("http://localhost:%d/api/virtual_container/0", app.getPort());
 
-        String response = UtilsTest.submitRequest(url, HttpMethod.PUT, jsonInput);
-        assertThat(response).isEqualToIgnoringCase("OK");
+        HttpURLConnection response = UtilsTest.submitRequest(url, HttpMethod.PUT, jsonInput);
+        assertThat(response.getResponseCode()).isEqualTo(Response.Status.OK.getStatusCode());
         String containerPrefix = Joiner.on(".").join(VirtualContainerResource.VIRTUAL_CONTAINER_PREFIX, "0");
         String primaryTierPrefix = Joiner.on(".").join(containerPrefix, VirtualContainer.PRIMARY_TIER_PREFIX);
         Configuration config = app.getConfiguration();
@@ -75,8 +77,8 @@ public class VirtualContainerResourceTest {
                 "\"copyDelay\":null,\"moveDelay\":null},\"name\":\"magic\"}";
 
         String url = String.format("http://localhost:%d/api/virtual_container/0", app.getPort());
-        String response = UtilsTest.submitRequest(url, HttpMethod.PUT, jsonInput);
-        assertThat(response).isEqualToIgnoringCase("OK");
+        HttpURLConnection response = UtilsTest.submitRequest(url, HttpMethod.PUT, jsonInput);
+        assertThat(response.getResponseCode()).isEqualTo(Response.Status.OK.getStatusCode());
         String containerPrefix = Joiner.on(".").join(VirtualContainerResource.VIRTUAL_CONTAINER_PREFIX, "0");
         String targetLocationPrefix = Joiner.on(".").join(containerPrefix, VirtualContainer.MIGRATION_TIER_PREFIX);
         Configuration config = app.getConfiguration();


### PR DESCRIPTION
The endpoint URL properties may not be set and we need to guard
against that when constructing the URL objects.

This bug manifests itself if the properties are not set and a GET
request is submitted to the /settings API.

Added unit tests to catch the following issues:
1. Querying empty settings
2. Setting S3 settings and querying them afterward
3. Setting Swift settings and querying them afterward

Fixes #183
