### PR TITLE
Update Dockerfile for java repository changes.

### DIFF
--- a/bounce/Dockerfile
+++ b/bounce/Dockerfile
@@ -1,4 +1,4 @@
-FROM dockerfile/java:oracle-java8
+FROM java:openjdk-8
 RUN curl https://s3.amazonaws.com/influxdb/influxdb_latest_amd64.deb -o /tmp/influxdb_latest_amd64.deb
 RUN dpkg -i /tmp/influxdb_latest_amd64.deb
 COPY setup_influxdb.sh /data/setup_influxdb.sh
@@ -8,4 +8,4 @@ COPY docker_entrypoint.sh /data/
 RUN mkdir -p /tmp/blobstore
 EXPOSE 8080 9000 9001 8086
 CMD []
-ENTRYPOINT ["/bin/bash", "./docker_entrypoint.sh"]
+ENTRYPOINT ["/bin/bash", "/data/docker_entrypoint.sh"]

--- a/bounce/docker_entrypoint.sh
+++ b/bounce/docker_entrypoint.sh
@@ -10,8 +10,8 @@ function sigterm_handler() {
 
 trap "sigterm_handler" TERM
 
-./setup_influxdb.sh
-java -jar ./bounce.jar --properties bounce.properties >& /var/log/bounce.log &
+/data/setup_influxdb.sh
+java -jar /data/bounce.jar --properties /data/bounce.properties >& /var/log/bounce.log &
 
 child=$!
 wait "$child"

--- a/bounce/setup_influxdb.sh
+++ b/bounce/setup_influxdb.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-setup_file=./setup
+setup_file=/data/setup
 
 service influxdb start
 


### PR DESCRIPTION
Docker no longer has oracle-java8 as an option, but does have an
openjdk-8 container. The commit moves us to using that container. It
also fixes path issues in the docker scripts.
