### PR TITLE
Allow for same container names in different OS.

### DIFF
--- a/bounce/src/main/resources/assets/javascript/storesControllers.js
+++ b/bounce/src/main/resources/assets/javascript/storesControllers.js
@@ -193,13 +193,20 @@ storesControllers.controller('ViewStoresCtrl', ['$scope', '$location',
         console.log("blob store ID not found");
         return [];
       }
-      return $scope.containersMap[blobStoreId].filter(
-        function(container) {
-          return (container.status === 'UNCONFIGURED' &&
-                  container.name !== $scope.enhanceContainer.name) ||
-                 (container.status === 'INUSE' &&
-                  container.name === editLocation.containerName);
-        });
+      if (blobStoreId === $scope.enhanceContainer.originLocation.blobStoreId) {
+        return $scope.containersMap[blobStoreId].filter(
+          function(container) {
+            return (container.status === 'UNCONFIGURED' &&
+                    container.name !== $scope.enhanceContainer.name) ||
+                   (container.status === 'INUSE' &&
+                    container.name === editLocation.containerName);
+          });
+      } else {
+        return $scope.containersMap[blobStoreId].filter(
+          function(container) {
+            return container.status === 'UNCONFIGURED';
+          });
+      }
     };
 
     $scope.actions.enhanceContainer = function(container) {


### PR DESCRIPTION
If two object stores have containers with the same name, we should
allow them to be used in tiering (previously, UI would filter out
containers with the same name as the one being configured).

Fixes #209
