### PR TITLE
Guard against keystoreutils not being initialized.

### DIFF
--- a/bounce/src/main/java/com/bouncestorage/bounce/admin/SettingsResource.java
+++ b/bounce/src/main/java/com/bouncestorage/bounce/admin/SettingsResource.java
@@ -21,6 +21,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import com.bouncestorage.bounce.utils.KeyStoreUtils;
 import com.bouncestorage.swiftproxy.SwiftProxy;
 import com.codahale.metrics.annotation.Timed;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -46,8 +47,11 @@ public class SettingsResource {
         Settings res = new Settings();
         res.s3Domain = app.getConfiguration().getString(S3ProxyConstants.PROPERTY_VIRTUAL_HOST);
         if (!Strings.isNullOrEmpty(res.s3Domain)) {
-            X509Certificate cert = app.getKeyStoreUtils().ensureCertificate("*." + res.s3Domain);
-            res.domainCertificate = app.getKeyStoreUtils().exportToPem(cert);
+            KeyStoreUtils keystore = app.getKeyStoreUtils();
+            if (keystore != null) {
+                X509Certificate cert = keystore.ensureCertificate("*." + res.s3Domain);
+                res.domainCertificate = keystore.exportToPem(cert);
+            }
         }
 
         String s3URL = app.getConfiguration().getString(S3ProxyConstants.PROPERTY_ENDPOINT);


### PR DESCRIPTION
We may hit an NPE if keystoreutils has not been initialized.
