### PR TITLE
Disable "migration" with other policies.

### DIFF
--- a/bounce/src/main/resources/assets/javascript/storesControllers.js
+++ b/bounce/src/main/resources/assets/javascript/storesControllers.js
@@ -79,14 +79,17 @@ function createNewVirtualContainer(store, container) {
 function extractLocations(vContainer) {
   return [{ name: 'a cache',
             edit_name: 'cache',
+            tier: BounceUtils.tiers.CACHE,
             object: vContainer.cacheLocation
           },
           { name: 'an archive',
             edit_name: 'archive',
+            tier: BounceUtils.tiers.ARCHIVE,
             object: vContainer.archiveLocation
           },
           { name: 'a migration target',
             edit_name: 'migration',
+            tier: BounceUtils.tiers.MIGRATION,
             object: vContainer.migrationTargetLocation
           }];
 }
@@ -219,6 +222,24 @@ storesControllers.controller('ViewStoresCtrl', ['$scope', '$location',
                            }
                           );
       return;
+    };
+
+    $scope.isLocationConfigurable = function(vLocation) {
+      if (vLocation.tier === BounceUtils.tiers.MIGRATION) {
+        var archive = $scope.enhanceContainer[BounceUtils.tiers.ARCHIVE.name];
+        if (archive.blobStoreId >= 0) {
+          return true;
+        }
+        var cache = $scope.enhanceContainer[BounceUtils.tiers.CACHE.name];
+        if (cache.blobStoreId >= 0) {
+          return true;
+        }
+
+        return false;
+      }
+
+      var migration = $scope.enhanceContainer[BounceUtils.tiers.MIGRATION.name];
+      return migration.blobStoreId >= 0;
     };
 
     $scope.listVirtualContainer = function(virtualContainer) {

--- a/bounce/src/main/resources/assets/views/partials/stores.html
+++ b/bounce/src/main/resources/assets/views/partials/stores.html
@@ -77,7 +77,9 @@
           <div class="row" ng-repeat="location in locations">
             <p>
               <div ng-if="location.object.blobStoreId === -1" class="col-sm-6">
-                <button class="btn btn-default" ng-click="actions.prompt(location)">
+                <button class="btn btn-default"
+                    ng-click="actions.prompt(location)"
+                    ng-disabled="isLocationConfigurable(location)">
                   Add {{location.name}}
                 </button>
               </div>


### PR DESCRIPTION
We currently do not support enabling "migration" with other policies
present (caching or archival). The patch disables the migration option
in the UI if another policy is configured and disables other policies
if migration is set.

Fixes #207
