### PR TITLE
Fix storage class object store creation bug.

### DIFF
--- a/bounce/src/main/java/com/bouncestorage/bounce/admin/ObjectStoreResource.java
+++ b/bounce/src/main/java/com/bouncestorage/bounce/admin/ObjectStoreResource.java
@@ -345,6 +345,9 @@ public final class ObjectStoreResource {
                 properties.put(propertiesPrefix + "region", region);
             }
             properties.put(propertiesPrefix + "nickname", nickname);
+            if (storageClass != null) {
+                properties.put(propertiesPrefix + "storageClass", storageClass.toString());
+            }
 
             return properties;
         }

--- a/bounce/src/main/resources/assets/javascript/storesControllers.js
+++ b/bounce/src/main/resources/assets/javascript/storesControllers.js
@@ -31,7 +31,8 @@ storesControllers.controller('CreateStoreCtrl', ['$scope', '$rootScope',
                        identity: $scope.provider.identity,
                        credential: $scope.provider.credential,
                        region: $scope.provider.region,
-                       endpoint: $scope.provider.endpoint
+                       endpoint: $scope.provider.endpoint,
+                       storageClass: $scope.provider.class
                      };
       ObjectStore.save(newStore, function (successStore) {
         $rootScope.$emit('addedStore', successStore);


### PR DESCRIPTION
Currently, if an object store is created with a storage class, the
class is dropped entirely on the backend and front end. The patch
amends the plumbing for it.

Fixes #216
