### PR TITLE
Fix labels for container prompts.

### DIFF
--- a/bounce/src/main/resources/assets/javascript/storesControllers.js
+++ b/bounce/src/main/resources/assets/javascript/storesControllers.js
@@ -80,16 +80,19 @@ function createNewVirtualContainer(store, container) {
 function extractLocations(vContainer) {
   return [{ name: 'a cache',
             edit_name: 'cache',
+            action_label: 'from the cache',
             tier: BounceUtils.tiers.CACHE,
             object: vContainer.cacheLocation
           },
           { name: 'an archive',
             edit_name: 'archive',
+            action_label: 'to the archive',
             tier: BounceUtils.tiers.ARCHIVE,
             object: vContainer.archiveLocation
           },
           { name: 'a migration target',
             edit_name: 'migration',
+            action_label: 'to the migration target',
             tier: BounceUtils.tiers.MIGRATION,
             object: vContainer.migrationTargetLocation
           }];

--- a/bounce/src/main/resources/assets/views/partials/stores.html
+++ b/bounce/src/main/resources/assets/views/partials/stores.html
@@ -112,7 +112,7 @@
         <div class="container-fluid">
           <form class="form">
             <div class="form-group">
-              <label class="control-label">Cache container</label>
+              <label class="control-label">Container for the {{editLocation.edit_name}}</label>
               <div class="form-inline">
                 <select class="form-control" ng-model="editLocation.object.blobStoreId"
                     ng-options="store.id as store.nickname for store in stores">
@@ -126,7 +126,7 @@
               </div>
             </div>
             <div class="form-group">
-              <label class="control-label">Copy to {{enhanceContainer.name}} after:</label>
+              <label class="control-label">Copy {{editLocation.action_label}} after:</label>
               <div class="form-inline">
                 <input class="form-control" type="text" ng-model="editLocation.copyDuration"
                     placeholder="duration" />
@@ -137,7 +137,7 @@
               </div>
             </div>
             <div class="form-group">
-              <label class="control-label">Move to {{enhanceContainer.name}} after:</label>
+              <label class="control-label">Move {{editLocation.action_label}} after:</label>
               <div class="form-inline">
                 <input class="form-control" type="text" ng-model="editLocation.moveDuration"
                     placeholder="duration" />


### PR DESCRIPTION
In a number of places we are using incorrect labels when editing a
container. Specifically, every tier has the top label "Сache"; the
container that is configured is also incorrect.

Fixes #218, #219
