### PR TITLE
Do not display the time prompts for migration.

### DIFF
--- a/bounce/src/main/resources/assets/javascript/storesControllers.js
+++ b/bounce/src/main/resources/assets/javascript/storesControllers.js
@@ -129,6 +129,7 @@ storesControllers.controller('ViewStoresCtrl', ['$scope', '$location',
     $scope.newContainer = null;
     $scope.providerLabel = null;
     $scope.durationUnits = BounceUtils.durationUnits;
+    $scope.tiers = BounceUtils.tiers;
 
     $scope.getProviderLabel = function() {
       if ($scope.store.region === null) {

--- a/bounce/src/main/resources/assets/views/partials/stores.html
+++ b/bounce/src/main/resources/assets/views/partials/stores.html
@@ -125,7 +125,7 @@
                 </select>
               </div>
             </div>
-            <div class="form-group">
+            <div class="form-group" ng-if="editLocation.tier !== tiers.MIGRATION">
               <label class="control-label">Copy {{editLocation.action_label}} after:</label>
               <div class="form-inline">
                 <input class="form-control" type="text" ng-model="editLocation.copyDuration"
@@ -136,7 +136,7 @@
                 </select>
               </div>
             </div>
-            <div class="form-group">
+            <div class="form-group" ng-if="editLocation.tier !== tiers.MIGRATION">
               <label class="control-label">Move {{editLocation.action_label}} after:</label>
               <div class="form-inline">
                 <input class="form-control" type="text" ng-model="editLocation.moveDuration"


### PR DESCRIPTION
For the migration policy, we do not need to prompt for the time when
we perform copy or move operations.
