### PR TITLE
List the container recursively in bucket explorer.

### DIFF
--- a/bounce/src/main/java/com/bouncestorage/bounce/admin/ContainerResource.java
+++ b/bounce/src/main/java/com/bouncestorage/bounce/admin/ContainerResource.java
@@ -117,7 +117,7 @@ public final class ContainerResource {
             throw new WebApplicationException(Response.Status.NOT_FOUND);
         }
         List<ContainerObject> objects = blobStore.list(containerName,
-                ListContainerOptions.Builder.maxResults(MAX_OBJECTS))
+                ListContainerOptions.Builder.maxResults(MAX_OBJECTS).recursive())
                 .stream()
                 .map(sm -> {
                     ImmutableSet<BounceStorageMetadata.Region> regions;


### PR DESCRIPTION
Pass the recursive option to the list() method when listing containers
for the bucket explorer.

Fixes #211
