### PR TITLE
Use unlimitedThreads in tests.

### DIFF
--- a/bounce/pom.xml
+++ b/bounce/pom.xml
@@ -131,7 +131,7 @@
                 <version>2.18.1</version>
                 <configuration>
                     <parallel>methods</parallel>
-                    <threadCount>1</threadCount>
+                    <useUnlimitedThreads>true</useUnlimitedThreads>
                     <argLine>-Xmx128m</argLine>
                     <forkCount>0</forkCount>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>


### PR DESCRIPTION
Increases the degree of parallelism in tests by using the
unlimitedThreads option. This seems to work correctly including on the
nightly.
