### PR TITLE
run all the tests in parallel

### DIFF
--- a/bounce/pom.xml
+++ b/bounce/pom.xml
@@ -130,8 +130,8 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.18.1</version>
                 <configuration>
-                    <parallel>methods</parallel>
-                    <threadCount>1</threadCount>
+                    <parallel>all</parallel>
+                    <threadCount>4</threadCount>
                     <argLine>-Xmx128m</argLine>
                     <forkCount>0</forkCount>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>

--- a/bounce/src/test/java/com/bouncestorage/bounce/BounceApplicationTest.java
+++ b/bounce/src/test/java/com/bouncestorage/bounce/BounceApplicationTest.java
@@ -57,7 +57,7 @@ public final class BounceApplicationTest {
 
     @Test
     public void testSwiftProxyStartup() throws Exception {
-        app = new BounceApplication();
+        app = UtilsTest.newBounceApplication();
         BounceConfiguration config = app.getConfiguration();
         config.setProperty(SwiftProxy.PROPERTY_ENDPOINT, "http://127.0.0.1:0");
         startApp();
@@ -104,7 +104,7 @@ public final class BounceApplicationTest {
         try (InputStream is = BounceApplicationTest.class.getResourceAsStream("/bounce.properties")) {
             properties.load(is);
         }
-        app = new BounceApplication();
+        app = UtilsTest.newBounceApplication();
         app.getConfiguration().setAll(properties);
     }
 

--- a/bounce/src/test/java/com/bouncestorage/bounce/BounceTest.java
+++ b/bounce/src/test/java/com/bouncestorage/bounce/BounceTest.java
@@ -13,7 +13,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.io.ByteSource;
 
 import org.jclouds.blobstore.BlobStore;
-import org.jclouds.blobstore.BlobStoreContext;
 import org.jclouds.blobstore.domain.Blob;
 import org.jclouds.blobstore.domain.BlobMetadata;
 import org.jclouds.blobstore.options.GetOptions;
@@ -23,7 +22,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 public final class BounceTest {
-    private BlobStoreContext bounceContext;
     private BlobStore nearBlobStore;
     private BlobStore farBlobStore;
     private BouncePolicy policy;
@@ -31,6 +29,7 @@ public final class BounceTest {
 
     @Before
     public void setUp() throws Exception {
+        UtilsTest.newBounceApplication();
         containerName = UtilsTest.createRandomContainerName();
 
         policy = new WriteBackPolicy();
@@ -45,9 +44,6 @@ public final class BounceTest {
     public void tearDown() throws Exception {
         if (policy != null) {
             policy.deleteContainer(containerName);
-        }
-        if (bounceContext != null) {
-            bounceContext.close();
         }
     }
 

--- a/bounce/src/test/java/com/bouncestorage/bounce/EncryptedBlobStoreTest.java
+++ b/bounce/src/test/java/com/bouncestorage/bounce/EncryptedBlobStoreTest.java
@@ -34,6 +34,7 @@ public final class EncryptedBlobStoreTest {
 
     @Before
     public void setUp() throws Exception {
+        UtilsTest.newBounceApplication();
         containerName = UtilsTest.createRandomContainerName();
         Properties properties = new Properties();
         properties.putAll(ImmutableMap.of(

--- a/bounce/src/test/java/com/bouncestorage/bounce/UtilsTest.java
+++ b/bounce/src/test/java/com/bouncestorage/bounce/UtilsTest.java
@@ -44,6 +44,8 @@ import com.google.common.io.ByteSource;
 import com.google.common.net.MediaType;
 import com.google.inject.Module;
 
+import io.dropwizard.logging.LoggingFactory;
+
 import org.apache.commons.configuration.Configuration;
 import org.assertj.core.api.AbstractLongAssert;
 import org.jclouds.Constants;
@@ -58,6 +60,7 @@ import org.jclouds.logging.slf4j.config.SLF4JLoggingModule;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.LoggerFactory;
 
 public final class UtilsTest {
     private BlobStoreContext nearContext;
@@ -147,15 +150,15 @@ public final class UtilsTest {
             assertThat(expected).isNotNull();
             try (InputStream is = actual.getPayload().openStream();
                  InputStream is2 = expected.getPayload().openStream()) {
-                assertThat(is).hasContentEqualTo(is2);
+                assertThat(is).as(actual.getMetadata().getName()).hasContentEqualTo(is2);
             }
             // TODO: assert more metadata, including user metadata
             ContentMetadata metadata = actual.getMetadata().getContentMetadata();
             ContentMetadata metadata2 = expected.getMetadata().getContentMetadata();
-            assertThat(metadata.getContentMD5AsHashCode()).isEqualTo(
-                    metadata2.getContentMD5AsHashCode());
-            assertThat(metadata.getContentType()).isEqualTo(
-                    metadata2.getContentType());
+            assertThat(metadata.getContentMD5AsHashCode()).as(actual.getMetadata().getName())
+                    .isEqualTo(metadata2.getContentMD5AsHashCode());
+            assertThat(metadata.getContentType()).as(actual.getMetadata().getName())
+                    .isEqualTo(metadata2.getContentType());
         }
     }
 
@@ -369,4 +372,13 @@ public final class UtilsTest {
         }
     }
 
+    public static BounceApplication newBounceApplication() throws Exception {
+        try {
+            return new BounceApplication();
+        } catch (Exception e) {
+            LoggingFactory.bootstrap();
+            assertThat(LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME)).isNotNull();
+            throw e;
+        }
+    }
 }

--- a/bounce/src/test/java/com/bouncestorage/bounce/admin/AboutResourceTest.java
+++ b/bounce/src/test/java/com/bouncestorage/bounce/admin/AboutResourceTest.java
@@ -9,6 +9,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Properties;
 
+import com.bouncestorage.bounce.UtilsTest;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -16,7 +18,8 @@ public final class AboutResourceTest {
     private AboutResource resource;
 
     @Before
-    public void setup() {
+    public void setup() throws Exception {
+        UtilsTest.newBounceApplication();
         resource = new AboutResource();
     }
 

--- a/bounce/src/test/java/com/bouncestorage/bounce/admin/AdminTest.java
+++ b/bounce/src/test/java/com/bouncestorage/bounce/admin/AdminTest.java
@@ -41,7 +41,7 @@ public final class AdminTest {
 
         String config = getClass().getResource("/bounce.yml").toExternalForm();
         synchronized (BounceApplication.class) {
-            app = new BounceApplication();
+            app = UtilsTest.newBounceApplication();
             app.getConfiguration().setAll(properties);
             app.useRandomPorts();
             app.registerConfigurationListener();

--- a/bounce/src/test/java/com/bouncestorage/bounce/admin/BounceServiceTest.java
+++ b/bounce/src/test/java/com/bouncestorage/bounce/admin/BounceServiceTest.java
@@ -32,7 +32,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public final class BounceServiceTest {
-    private Logger logger = LoggerFactory.getLogger(getClass());
+    private Logger logger;
     private BouncePolicy policy;
     private String containerName;
     private BounceService bounceService;
@@ -43,7 +43,8 @@ public final class BounceServiceTest {
         containerName = UtilsTest.createRandomContainerName();
 
         synchronized (BounceApplication.class) {
-            app = new BounceApplication();
+            app = UtilsTest.newBounceApplication();
+            logger = LoggerFactory.getLogger(getClass());
         }
         app.useRandomPorts();
         app.registerConfigurationListener();

--- a/bounce/src/test/java/com/bouncestorage/bounce/admin/BounceStatsTest.java
+++ b/bounce/src/test/java/com/bouncestorage/bounce/admin/BounceStatsTest.java
@@ -11,11 +11,20 @@ import java.util.List;
 
 import javax.ws.rs.HttpMethod;
 
+import com.bouncestorage.bounce.UtilsTest;
+
 import org.influxdb.dto.Serie;
+import org.junit.Before;
 import org.junit.Test;
 
 public class BounceStatsTest {
-    private BounceStats stats = new BounceStats();
+    private BounceStats stats;
+
+    @Before
+    public void setUp() throws Exception {
+        UtilsTest.newBounceApplication();
+        stats = new BounceStats();
+    }
 
     @Test
     public void testNoStats() {

--- a/bounce/src/test/java/com/bouncestorage/bounce/admin/ConfigTest.java
+++ b/bounce/src/test/java/com/bouncestorage/bounce/admin/ConfigTest.java
@@ -46,7 +46,7 @@ public final class ConfigTest {
         }
 
         synchronized (BounceApplication.class) {
-            app = new BounceApplication();
+            app = UtilsTest.newBounceApplication();
         }
         app.getConfiguration().setAll(properties);
         app.useRandomPorts();
@@ -56,15 +56,17 @@ public final class ConfigTest {
 
     @After
     public void tearDown() throws Exception {
-        BlobStore blobStore = app.getBlobStore();
-        if (blobStore != null) {
-            blobStore.deleteContainer(containerName);
-        }
-        if (blobStore != null && blobStore.getContext() != null) {
-            blobStore.getContext().close();
-        }
+        if (app != null) {
+            BlobStore blobStore = app.getBlobStore();
+            if (blobStore != null) {
+                blobStore.deleteContainer(containerName);
+            }
+            if (blobStore != null && blobStore.getContext() != null) {
+                blobStore.getContext().close();
+            }
 
-        app.stop();
+            app.stop();
+        }
     }
 
     @Test

--- a/bounce/src/test/java/com/bouncestorage/bounce/admin/ObjectStoreResourceTest.java
+++ b/bounce/src/test/java/com/bouncestorage/bounce/admin/ObjectStoreResourceTest.java
@@ -51,7 +51,9 @@ public class ObjectStoreResourceTest {
 
     @After
     public void tearDown() throws Exception {
-        app.stop();
+        if (app != null) {
+            app.stop();
+        }
         if (configFile != null) {
             configFile.delete();
         }

--- a/bounce/src/test/java/com/bouncestorage/bounce/admin/SettingsResourceTest.java
+++ b/bounce/src/test/java/com/bouncestorage/bounce/admin/SettingsResourceTest.java
@@ -11,6 +11,8 @@ import java.util.Random;
 
 import javax.ws.rs.core.Response;
 
+import com.bouncestorage.bounce.UtilsTest;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -21,7 +23,7 @@ public class SettingsResourceTest {
 
     @Before
     public void setUp() throws Exception {
-        app = new BounceApplication();
+        app = UtilsTest.newBounceApplication();
         app.useRandomPorts();
         app.initTestingKeyStore();
         String webConfig = SettingsResourceTest.class.getResource("/bounce.yml").toExternalForm();

--- a/bounce/src/test/java/com/bouncestorage/bounce/admin/VirtualContainerResourceTest.java
+++ b/bounce/src/test/java/com/bouncestorage/bounce/admin/VirtualContainerResourceTest.java
@@ -28,7 +28,7 @@ public class VirtualContainerResourceTest {
 
     @Before
     public void setUp() throws Exception {
-        app = new BounceApplication();
+        app = UtilsTest.newBounceApplication();
         app.useRandomPorts();
         app.getConfiguration().setAll(getDefaultProperties());
         String webConfig = VirtualContainerResourceTest.class.getResource("/bounce.yml").toExternalForm();

--- a/bounce/src/test/java/com/bouncestorage/bounce/admin/policy/MigrationPolicyTest.java
+++ b/bounce/src/test/java/com/bouncestorage/bounce/admin/policy/MigrationPolicyTest.java
@@ -47,7 +47,7 @@ public final class MigrationPolicyTest {
         containerName = UtilsTest.createRandomContainerName();
 
         synchronized (BounceApplication.class) {
-            app = new BounceApplication();
+            app = UtilsTest.newBounceApplication();
         }
         app.useRandomPorts();
         app.registerConfigurationListener();

--- a/bounce/src/test/java/com/bouncestorage/bounce/admin/policy/WriteBackPolicyAutoWriteBackTest.java
+++ b/bounce/src/test/java/com/bouncestorage/bounce/admin/policy/WriteBackPolicyAutoWriteBackTest.java
@@ -31,7 +31,7 @@ public final class WriteBackPolicyAutoWriteBackTest {
         containerName = UtilsTest.createRandomContainerName();
 
         synchronized (BounceApplication.class) {
-            app = new BounceApplication();
+            app = UtilsTest.newBounceApplication();
         }
         app.useRandomPorts();
         app.registerConfigurationListener();

--- a/bounce/src/test/java/com/bouncestorage/bounce/admin/policy/WriteBackPolicyTest.java
+++ b/bounce/src/test/java/com/bouncestorage/bounce/admin/policy/WriteBackPolicyTest.java
@@ -56,7 +56,7 @@ public class WriteBackPolicyTest {
         containerName = UtilsTest.createRandomContainerName();
 
         synchronized (BounceApplication.class) {
-            app = new BounceApplication();
+            app = UtilsTest.newBounceApplication();
             // need to initialize logger after dropwizard application init
             logger = LoggerFactory.getLogger(WriteBackPolicyTest.class);
         }
@@ -82,7 +82,9 @@ public class WriteBackPolicyTest {
             policy.deleteContainer(containerName);
         }
 
-        app.resumeBackgroundTasks();
+        if (app != null) {
+            app.resumeBackgroundTasks();
+        }
     }
 
     @Test


### PR DESCRIPTION
always create a BounceApplication even if the tests don't need it,
so that they won't race with DropWizard's static initializer. It's
not clear why this happens, but seems to work
