### PR TITLE
Do not supply metadata when performing a copy.

### DIFF
--- a/bounce/src/test/java/com/bouncestorage/bounce/admin/policy/MigrationPolicyTest.java
+++ b/bounce/src/test/java/com/bouncestorage/bounce/admin/policy/MigrationPolicyTest.java
@@ -28,7 +28,6 @@ import com.bouncestorage.bounce.admin.BouncePolicy;
 import com.bouncestorage.bounce.admin.BounceService;
 import com.bouncestorage.bounce.admin.BounceStats;
 import com.bouncestorage.bounce.admin.StatsQueueEntry;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.io.ByteSource;
 
 import org.jclouds.blobstore.domain.Blob;
@@ -244,8 +243,7 @@ public final class MigrationPolicyTest {
         Blob blob = UtilsTest.makeBlob(policy, blobName, ByteSource.empty());
 
         policy.getDestination().putBlob(containerName, blob);
-        policy.copyBlob(containerName, blobName, containerName, copyBlobName,
-                CopyOptions.builder().userMetadata(ImmutableMap.of("x", "1")).build());
+        policy.copyBlob(containerName, blobName, containerName, copyBlobName, CopyOptions.NONE);
         assertEqualBlobs(policy.getBlob(containerName, copyBlobName), blob);
     }
 


### PR DESCRIPTION
Amazon preserves metadata when performing PUT Object Copy if there is
no metadata supplied. We should either supply the full set of metadata
in the request or pass CopyOptions.NONE. The patch changes the test to
the latter.
