### PR TITLE
Explicitly set jclouds.headers to debug.

### DIFF
--- a/bounce/src/test/resources/logback-test.xml
+++ b/bounce/src/test/resources/logback-test.xml
@@ -10,6 +10,7 @@
 
   <logger name="org.eclipse.jetty" level="${JETTY_LOG_LEVEL:-info}" />
   <logger name="jclouds.wire" level="info"/>
+  <logger name="jclouds.headers" level="debug"/>
 
   <root level="${LOG_LEVEL:-debug}">
     <appender-ref ref="STDOUT" />


### PR DESCRIPTION
Setting jclouds.headers to debug level ensures that all unit tests
that interact with jclouds will also log the headers.
