### PR TITLE
Do not bounce application/directory blobs.

### DIFF
--- a/bounce/src/main/java/com/bouncestorage/bounce/BounceStorageMetadata.java
+++ b/bounce/src/main/java/com/bouncestorage/bounce/BounceStorageMetadata.java
@@ -11,8 +11,10 @@ import java.util.Set;
 
 import com.google.common.collect.ImmutableSet;
 
+import org.jclouds.blobstore.domain.BlobMetadata;
 import org.jclouds.blobstore.domain.StorageMetadata;
 import org.jclouds.blobstore.domain.internal.MutableStorageMetadataImpl;
+import org.jclouds.io.ContentMetadata;
 
 public final class BounceStorageMetadata extends MutableStorageMetadataImpl {
     public enum Region {
@@ -27,9 +29,13 @@ public final class BounceStorageMetadata extends MutableStorageMetadataImpl {
     private final ImmutableSet<Region> regions;
     private boolean hasMarkerBlob;
     private long linkSize;
+    private ContentMetadata contentMetadata;
 
     public BounceStorageMetadata(StorageMetadata metadata, Set<Region> regions) {
         super(metadata);
+        if (metadata instanceof BlobMetadata) {
+            contentMetadata = ((BlobMetadata) metadata).getContentMetadata();
+        }
         this.regions = ImmutableSet.copyOf(requireNonNull(regions));
     }
 
@@ -51,5 +57,9 @@ public final class BounceStorageMetadata extends MutableStorageMetadataImpl {
 
     public ImmutableSet<Region> getRegions() {
         return regions;
+    }
+
+    public ContentMetadata contentMetadata() {
+        return contentMetadata;
     }
 }

--- a/bounce/src/main/java/com/bouncestorage/bounce/admin/policy/StoragePolicy.java
+++ b/bounce/src/main/java/com/bouncestorage/bounce/admin/policy/StoragePolicy.java
@@ -67,6 +67,12 @@ public class StoragePolicy extends WriteBackPolicy {
             return super.reconcileObject(container, sourceObject, destinationObject);
         }
 
+        if (sourceObject.contentMetadata() != null) {
+            if (sourceObject.contentMetadata().getContentType().equals("application/directory")) {
+                return BounceResult.NO_OP;
+            }
+        }
+
         if (currentSize < capacity) {
             return super.reconcileObject(container, sourceObject, destinationObject);
         }


### PR DESCRIPTION
We should not bounce the application/directory blobs in the
WriteBackPolicy. This allows Bounce to support Swift->S3 tiering,
where the original application may be using the Swift interface and
expects the listings to contain the Content-Type for directory blobs.
